### PR TITLE
background: Fix error message

### DIFF
--- a/src/background/main.rs
+++ b/src/background/main.rs
@@ -83,7 +83,7 @@ fn main() {
 
     match Image::from_path(&path) {
         Ok(image) => {
-            let (display_width, display_height) = orbclient::get_display_size().expect("viewer: failed to get display size");
+            let (display_width, display_height) = orbclient::get_display_size().expect("background: failed to get display size");
 
             let mut window = Window::new_flags(
                 0, 0, display_width, display_height, "",


### PR DESCRIPTION
The application name wasn't changed in this error message when the code was copied from the image viewer.