### PR TITLE
file_manager: Fix panic on Unicode filenames

### DIFF
--- a/src/file_manager/main.rs
+++ b/src/file_manager/main.rs
@@ -129,8 +129,7 @@ impl FileType {
         if file_name.ends_with('/') {
             Self::new("folder".to_owned(), "inode-directory")
         } else {
-            let pos = file_name.rfind('.').unwrap_or(0) + 1;
-            let ext = &file_name[pos..];
+            let ext = file_name.rsplitn(2, '.').next().unwrap_or("");
             let mime = mime_guess::get_mime_type(ext);
             let image = match (&mime.0, &mime.1) {
                 (&MimeTop::Image, _) => "image-x-generic",


### PR DESCRIPTION
This PR fixes a problem where the File Manager panicked on trying to extract the file extension of Unicode filenames. The code assumed that the UTF-8 characters are one byte long. (They're not.)

For example trying to list a file named "ő" (Char: `U+0151`, UTF-8: `0xC5 0x91`) produced the following panic:

```
thread 'main' panicked at 'byte index 1 is not a char boundary; it is inside 'ő' (bytes 0..2) of `ő`'
```
